### PR TITLE
Fix test client converting empty lists/dicts to empty string

### DIFF
--- a/rest_framework/test.py
+++ b/rest_framework/test.py
@@ -34,7 +34,7 @@ class APIRequestFactory(DjangoRequestFactory):
         Encode the data returning a two tuple of (bytes, content_type)
         """
 
-        if not data:
+        if data is None:
             return ('', None)
 
         assert format is None or content_type is None, (


### PR DESCRIPTION
Because, you know.
